### PR TITLE
 Delete FAQ's section

### DIFF
--- a/Modelica_LinearSystems2/UsersGuide.mo
+++ b/Modelica_LinearSystems2/UsersGuide.mo
@@ -518,16 +518,16 @@ Germany<br>
 email: Martin.Otter@dlr.de
 </p>
 
+<!--
 <p>
 <a href=\"#3clauseBSD_License-outline\">3-clause BSD License</a><br>
 <a href=\"#Frequently_Asked_Questions-outline\">Frequently Asked Questions</a><br>
 </p>
 
 <hr>
+-->
 
 <h4><a name=\"3clauseBSD_License-outline\"></a>The 3-clause BSD License</h4>
-
-<div class=\"\" id=\"parent-fieldname-text\">
 <p>
 Copyright 
 <br>&copy; 2005-2012, DLR Institute of Robotics and Mechatronics
@@ -570,244 +570,6 @@ The above is the license, and is the standard
 <a href=\"https://opensource.org/licenses/BSD-3-Clause\">3-clause BSD-license</a>
 with DLR Institute of System Dynamics and Control as copyright holder.
 </p>
-
-<hr>
-
-<h4><a name=\"Frequently_Asked_Questions-outline\"></a>
-Frequently Asked Questions</h4>
-<p>This
-section contains questions/answer to users and/or distributors of
-Modelica packages and/or documents under Modelica License 2. Note,
-the answers to the questions below are not a legal interpretation of
-the Modelica License 2. In case of a conflict, the language of the
-license shall prevail.</p>
-
-<h6>Using or Distributing a Modelica <u>Package</u> under the Modelica License 2</h6>
-
-<p><b>What are the main
-differences to the previous version of the Modelica License?</b></p>
-<ol>
-	<li><p>
-	Modelica License 1 is unclear whether the licensed Modelica package
-	can be distributed under a different license. Version 2 explicitly
-	allows that &ldquo;Derivative Work&rdquo; can be distributed under
-	any license of Your choice, see examples in Section 1d) as to what
-	qualifies as Derivative Work (so, version 2 is clearer).</p>
-	<li><p>
-	If You modify a Modelica package under Modelica License 2 (besides
-	fixing of errors, adding vendor specific Modelica annotations, using
-	a subset of the classes of a Modelica package, or using another
-	representation, e.g., a binary representation), you must rename the
-	root-level name of the package for your distribution. In version 1
-	you could keep the name (so, version 2 is more restrictive). The
-	reason of this restriction is to reduce the risk that Modelica
-	packages are available that have identical names, but different
-	functionality.</p>
-	<li><p>
-	Modelica License 1 states that &ldquo;It is not allowed to charge a
-	fee for the original version or a modified version of the software,
-	besides a reasonable fee for distribution and support&rdquo;.
-	Version 2 has a similar intention for all Original Work under
-	<u>Modelica License 2</u> (to remain free of charge and open source)
-	but states this more clearly as &ldquo;No fee, neither as a
-	copyright-license fee, nor as a selling fee for the copy as such may
-	be charged&rdquo;. Contrary to version 1, Modelica License 2 has no
-	restrictions on fees for Derivative Work that is provided under a
-	different license (so, version 2 is clearer and has fewer
-	restrictions).</p>
-	<li><p>
-	Modelica License 2 introduces several useful provisions for the
-	licensee (articles 5, 6, 12), and for the licensor (articles 7, 12,
-	13, 14) that have no counter part in version 1.</p>
-	<li><p>
-	Modelica License 2 can be applied to all type of work, including
-	documents, images and data files, contrary to version 1 that was
-	dedicated for software only (so, version 2 is more general).</p>
-</ol>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) as part of my commercial
-Modelica modeling and simulation environment?</b></p>
-<p>Yes,
-according to Section 2c). However, you are not allowed to charge a
-fee for this part of your environment. Of course, you can charge for
-your part of the environment.
-</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different
-license?</b></p>
-<p>No.
-The license of an unmodified Modelica package cannot be changed
-according to Sections 2c) and 2d). This means that you cannot <u>sell</u>
-copies of it, any distribution has to be free of charge.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different license
-when I first encrypt the package?</b></p>
-<p>No.
-Merely encrypting a package does not qualify for Derivative Work and
-therefore the encrypted package has to stay under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different license
-when I first add classes to the package?</b></p>
-<p>No.
-The package itself remains unmodified, i.e., it is Original Work, and
-therefore the license for this part must remain under Modelica
-License 2. The newly added classes can be, however, under a different
-license.
-</p>
-
-<p><b>Can
-I copy a class out of a Modelica package (under Modelica License 2)
-and include it </b><u><b>unmodified</b></u><b> in a Modelica package
-under a </b><u><b>commercial/proprietary license</b></u><b>?</b></p>
-<p>No,
-according to article 2c). However, you can include model, block,
-function, package, record and connector classes in your Modelica
-package under <u>Modelica License 2</u>. This means that your
-Modelica package could be under a commercial/proprietary license, but
-one or more classes of it are under Modelica License 2.<br>Note, a
-&ldquo;type&rdquo; class (e.g., type Angle = Real(unit=&rdquo;rad&rdquo;))
-can be copied and included unmodified under a commercial/proprietary
-license (for details, see the next question).</p>
-
-<p><b>Can
-I copy a type class or </b><u><b>part</b></u><b> of a model, block,
-function, record, connector class, out of a Modelica package (under
-Modelica License 2) and include it modified or unmodified in a
-Modelica package under a </b><u><b>commercial/proprietary</b></u><b>
-license</b></p>
-<p>Yes,
-according to article 2d), since this will in the end usually qualify
-as Derivative Work. The reasoning is the following: A type class or
-part of another class (e.g., an equation, a declaration, part of a
-class description) cannot be utilized &ldquo;by its own&rdquo;. In
-order to make this &ldquo;usable&rdquo;, you have to add additional
-code in order that the class can be utilized. This is therefore
-usually Derivative Work and Derivative Work can be provided under a
-different license. Note, this only holds, if the additional code
-introduced is sufficient to qualify for Derivative Work. Merely, just
-copying a class and changing, say, one character in the documentation
-of this class would be no Derivative Work and therefore the copied
-code would have to stay under Modelica License 2.</p>
-
-<p><b>Can
-I copy a class out of a Modelica package (under Modelica License 2)
-and include it in </b><u><b>modified </b></u><b>form in a
-</b><u><b>commercial/proprietary</b></u><b> Modelica package?</b></p>
-<p>Yes.
-If the modification can be seen as a &ldquo;Derivative Work&rdquo;,
-you can place it under your commercial/proprietary license. If the
-modification does not qualify as &ldquo;Derivative Work&rdquo; (e.g.,
-bug fixes, vendor specific annotations), it must remain under
-Modelica License 2. This means that your Modelica package could be
-under a commercial/proprietary license, but one or more parts of it
-are under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-&ldquo;save total model&rdquo; under my commercial/proprietary
-license, even if classes under Modelica License 2 are included?</b></p>
-<p>Your
-classes of the &ldquo;save total model&rdquo; can be distributed
-under your commercial/proprietary license, but the classes under
-Modelica License 2 must remain under Modelica License 2. This means
-you can distribute a &ldquo;save total model&rdquo;, but some parts
-might be under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) in encrypted form?</b></p>
-<p>Yes.
-Note, if the encryption does not allow &ldquo;copying&rdquo; of
-classes (in to unencrypted Modelica source code), you have to send
-the Modelica source code of this package to your customer, if he/she
-wishes it, according to article&nbsp;6.</p>
-
-<p><b>Can I distribute an
-executable under my commercial/proprietary license, if the model from
-which the executable is generated uses models from a Modelica package
-under Modelica License 2?</b></p>
-<p>Yes,
-according to article 2d), since this is seen as Derivative Work. The
-reasoning is the following: An executable allows the simulation of a
-concrete model, whereas models from a Modelica package (without
-pre-processing, translation, tool run-time library) are not able to
-be simulated without tool support. By the processing of the tool and
-by its run-time libraries, significant new functionality is added (a
-model can be simulated whereas previously it could not be simulated)
-and functionality available in the package is removed (e.g., to build
-up a new model by dragging components of the package is no longer
-possible with the executable).</p>
-
-<p><b>Is my modification to
-a Modelica package (under Modelica License 2) a Derivative Work?</b></p>
-<p>It
-is not possible to give a general answer to it. To be regarded as &quot;an
-original work of authorship&quot;, a derivative work must be
-different enough from the original or must contain a substantial
-amount of new material. Making minor changes or additions of little
-substance to a preexisting work will not qualify the work as a new
-version for such purposes.
-</p>
-
-<h6>Using or Distributing a Modelica <u>Document</u> under the Modelica License 2</h6>
-
-<p>This
-section is devoted especially for the following applications:</p>
-<ol type=\"a\">
-	<li><p>
-	A Modelica tool extracts information out of a Modelica package and
-	presents the result in form of a &ldquo;manual&rdquo; for this
-	package in, e.g., html, doc, or pdf format.</p>
-	<li><p>
-	The Modelica language specification is a document defining the
-	Modelica language. It will be licensed under Modelica License 2.</p>
-	<li><p>
-	Someone writes a book about the Modelica language and/or Modelica
-	packages and uses information which is available in the Modelica
-	language specification and/or the corresponding Modelica package.</p>
-</ol>
-
-<p><b>Can I sell a manual
-that was basically derived by extracting information automatically
-from a Modelica package under Modelica License 2 (e.g., a &ldquo;reference
-guide&rdquo; of the Modelica Standard Library):</b></p>
-<p>Yes.
-Extracting information from a Modelica package, and providing it in a
-human readable, suitable format, like html, doc or pdf format, where
-the content is significantly modified (e.g. tables with interface
-information are constructed from the declarations of the public
-variables) qualifies as Derivative Work and there are no restrictions
-to charge a fee for Derivative Work under alternative 2d).</p>
-
-<p><b>Can
-I copy a text passage out of a Modelica document (under Modelica
-License 2) and use it </b><u><b>unmodified</b></u><b> in my document
-(e.g. the Modelica syntax description in the Modelica Specification)?</b></p>
-<p>Yes.
-In case you distribute your document, the copied parts are still
-under Modelica License 2 and you are not allowed to charge a license
-fee for this part. You can, of course, charge a fee for the rest of
-your document.</p>
-
-<p><b>Can
-I copy a text passage out of a Modelica document (under Modelica
-License 2) and use it in </b><u><b>modified</b></u><b> form in my
-document?</b></p>
-<p>Yes,
-the creation of Derivative Works is allowed. In case the content is
-significantly modified this qualifies as Derivative Work and there
-are no restrictions to charge a fee for Derivative Work under
-alternative 2d).</p>
-
-<p><b>Can I sell a printed
-version of a Modelica document (under Modelica License 2), e.g., the
-Modelica Language Specification?</b></p>
-<p>No,
-if you are not the copyright-holder, since article 2c) does not allow
-a selling fee for a (in this case physical) copy. However, mere
-printing and shipping costs may be recovered.</p>
 </html>"));
 
   end The3clauseBSDLicense;
@@ -857,7 +619,7 @@ This library is based on the following references:
 
   package ReleaseNotes "Release notes"
     class Version_2_3_5 "Version 2.3.5 (March 20, 2019)"
-	  extends Modelica.Icons.ReleaseNotes;
+      extends Modelica.Icons.ReleaseNotes;
 
       annotation (Documentation(info="<html>
 <p>This version requires the <b>Modelica 3.2.3</b> Library.
@@ -872,6 +634,7 @@ Improvements in this version:
 </ul>
 </html>"));
     end Version_2_3_5;
+
     class Version_2_3_4 "Version 2.3.4 (March 11, 2016)"
       extends Modelica.Icons.ReleaseNotes;
 

--- a/Modelica_LinearSystems2/UsersGuide.mo
+++ b/Modelica_LinearSystems2/UsersGuide.mo
@@ -518,16 +518,16 @@ Germany<br>
 email: Martin.Otter@dlr.de
 </p>
 
+<!--
 <p>
 <a href=\"#3clauseBSD_License-outline\">3-clause BSD License</a><br>
 <a href=\"#Frequently_Asked_Questions-outline\">Frequently Asked Questions</a><br>
 </p>
 
 <hr>
+-->
 
 <h4><a name=\"3clauseBSD_License-outline\"></a>The 3-clause BSD License</h4>
-
-<div class=\"\" id=\"parent-fieldname-text\">
 <p>
 Copyright 
 <br>&copy; 2005-2012, DLR Institute of Robotics and Mechatronics
@@ -570,244 +570,6 @@ The above is the license, and is the standard
 <a href=\"https://opensource.org/licenses/BSD-3-Clause\">3-clause BSD-license</a>
 with DLR Institute of System Dynamics and Control as copyright holder.
 </p>
-
-<hr>
-
-<h4><a name=\"Frequently_Asked_Questions-outline\"></a>
-Frequently Asked Questions</h4>
-<p>This
-section contains questions/answer to users and/or distributors of
-Modelica packages and/or documents under Modelica License 2. Note,
-the answers to the questions below are not a legal interpretation of
-the Modelica License 2. In case of a conflict, the language of the
-license shall prevail.</p>
-
-<h6>Using or Distributing a Modelica <u>Package</u> under the Modelica License 2</h6>
-
-<p><b>What are the main
-differences to the previous version of the Modelica License?</b></p>
-<ol>
-	<li><p>
-	Modelica License 1 is unclear whether the licensed Modelica package
-	can be distributed under a different license. Version 2 explicitly
-	allows that &ldquo;Derivative Work&rdquo; can be distributed under
-	any license of Your choice, see examples in Section 1d) as to what
-	qualifies as Derivative Work (so, version 2 is clearer).</p>
-	<li><p>
-	If You modify a Modelica package under Modelica License 2 (besides
-	fixing of errors, adding vendor specific Modelica annotations, using
-	a subset of the classes of a Modelica package, or using another
-	representation, e.g., a binary representation), you must rename the
-	root-level name of the package for your distribution. In version 1
-	you could keep the name (so, version 2 is more restrictive). The
-	reason of this restriction is to reduce the risk that Modelica
-	packages are available that have identical names, but different
-	functionality.</p>
-	<li><p>
-	Modelica License 1 states that &ldquo;It is not allowed to charge a
-	fee for the original version or a modified version of the software,
-	besides a reasonable fee for distribution and support&rdquo;.
-	Version 2 has a similar intention for all Original Work under
-	<u>Modelica License 2</u> (to remain free of charge and open source)
-	but states this more clearly as &ldquo;No fee, neither as a
-	copyright-license fee, nor as a selling fee for the copy as such may
-	be charged&rdquo;. Contrary to version 1, Modelica License 2 has no
-	restrictions on fees for Derivative Work that is provided under a
-	different license (so, version 2 is clearer and has fewer
-	restrictions).</p>
-	<li><p>
-	Modelica License 2 introduces several useful provisions for the
-	licensee (articles 5, 6, 12), and for the licensor (articles 7, 12,
-	13, 14) that have no counter part in version 1.</p>
-	<li><p>
-	Modelica License 2 can be applied to all type of work, including
-	documents, images and data files, contrary to version 1 that was
-	dedicated for software only (so, version 2 is more general).</p>
-</ol>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) as part of my commercial
-Modelica modeling and simulation environment?</b></p>
-<p>Yes,
-according to Section 2c). However, you are not allowed to charge a
-fee for this part of your environment. Of course, you can charge for
-your part of the environment.
-</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different
-license?</b></p>
-<p>No.
-The license of an unmodified Modelica package cannot be changed
-according to Sections 2c) and 2d). This means that you cannot <u>sell</u>
-copies of it, any distribution has to be free of charge.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different license
-when I first encrypt the package?</b></p>
-<p>No.
-Merely encrypting a package does not qualify for Derivative Work and
-therefore the encrypted package has to stay under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) under a different license
-when I first add classes to the package?</b></p>
-<p>No.
-The package itself remains unmodified, i.e., it is Original Work, and
-therefore the license for this part must remain under Modelica
-License 2. The newly added classes can be, however, under a different
-license.
-</p>
-
-<p><b>Can
-I copy a class out of a Modelica package (under Modelica License 2)
-and include it </b><u><b>unmodified</b></u><b> in a Modelica package
-under a </b><u><b>commercial/proprietary license</b></u><b>?</b></p>
-<p>No,
-according to article 2c). However, you can include model, block,
-function, package, record and connector classes in your Modelica
-package under <u>Modelica License 2</u>. This means that your
-Modelica package could be under a commercial/proprietary license, but
-one or more classes of it are under Modelica License 2.<br>Note, a
-&ldquo;type&rdquo; class (e.g., type Angle = Real(unit=&rdquo;rad&rdquo;))
-can be copied and included unmodified under a commercial/proprietary
-license (for details, see the next question).</p>
-
-<p><b>Can
-I copy a type class or </b><u><b>part</b></u><b> of a model, block,
-function, record, connector class, out of a Modelica package (under
-Modelica License 2) and include it modified or unmodified in a
-Modelica package under a </b><u><b>commercial/proprietary</b></u><b>
-license</b></p>
-<p>Yes,
-according to article 2d), since this will in the end usually qualify
-as Derivative Work. The reasoning is the following: A type class or
-part of another class (e.g., an equation, a declaration, part of a
-class description) cannot be utilized &ldquo;by its own&rdquo;. In
-order to make this &ldquo;usable&rdquo;, you have to add additional
-code in order that the class can be utilized. This is therefore
-usually Derivative Work and Derivative Work can be provided under a
-different license. Note, this only holds, if the additional code
-introduced is sufficient to qualify for Derivative Work. Merely, just
-copying a class and changing, say, one character in the documentation
-of this class would be no Derivative Work and therefore the copied
-code would have to stay under Modelica License 2.</p>
-
-<p><b>Can
-I copy a class out of a Modelica package (under Modelica License 2)
-and include it in </b><u><b>modified </b></u><b>form in a
-</b><u><b>commercial/proprietary</b></u><b> Modelica package?</b></p>
-<p>Yes.
-If the modification can be seen as a &ldquo;Derivative Work&rdquo;,
-you can place it under your commercial/proprietary license. If the
-modification does not qualify as &ldquo;Derivative Work&rdquo; (e.g.,
-bug fixes, vendor specific annotations), it must remain under
-Modelica License 2. This means that your Modelica package could be
-under a commercial/proprietary license, but one or more parts of it
-are under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-&ldquo;save total model&rdquo; under my commercial/proprietary
-license, even if classes under Modelica License 2 are included?</b></p>
-<p>Your
-classes of the &ldquo;save total model&rdquo; can be distributed
-under your commercial/proprietary license, but the classes under
-Modelica License 2 must remain under Modelica License 2. This means
-you can distribute a &ldquo;save total model&rdquo;, but some parts
-might be under Modelica License 2.</p>
-
-<p><b>Can I distribute a
-Modelica package (under Modelica License 2) in encrypted form?</b></p>
-<p>Yes.
-Note, if the encryption does not allow &ldquo;copying&rdquo; of
-classes (in to unencrypted Modelica source code), you have to send
-the Modelica source code of this package to your customer, if he/she
-wishes it, according to article&nbsp;6.</p>
-
-<p><b>Can I distribute an
-executable under my commercial/proprietary license, if the model from
-which the executable is generated uses models from a Modelica package
-under Modelica License 2?</b></p>
-<p>Yes,
-according to article 2d), since this is seen as Derivative Work. The
-reasoning is the following: An executable allows the simulation of a
-concrete model, whereas models from a Modelica package (without
-pre-processing, translation, tool run-time library) are not able to
-be simulated without tool support. By the processing of the tool and
-by its run-time libraries, significant new functionality is added (a
-model can be simulated whereas previously it could not be simulated)
-and functionality available in the package is removed (e.g., to build
-up a new model by dragging components of the package is no longer
-possible with the executable).</p>
-
-<p><b>Is my modification to
-a Modelica package (under Modelica License 2) a Derivative Work?</b></p>
-<p>It
-is not possible to give a general answer to it. To be regarded as &quot;an
-original work of authorship&quot;, a derivative work must be
-different enough from the original or must contain a substantial
-amount of new material. Making minor changes or additions of little
-substance to a preexisting work will not qualify the work as a new
-version for such purposes.
-</p>
-
-<h6>Using or Distributing a Modelica <u>Document</u> under the Modelica License 2</h6>
-
-<p>This
-section is devoted especially for the following applications:</p>
-<ol type=\"a\">
-	<li><p>
-	A Modelica tool extracts information out of a Modelica package and
-	presents the result in form of a &ldquo;manual&rdquo; for this
-	package in, e.g., html, doc, or pdf format.</p>
-	<li><p>
-	The Modelica language specification is a document defining the
-	Modelica language. It will be licensed under Modelica License 2.</p>
-	<li><p>
-	Someone writes a book about the Modelica language and/or Modelica
-	packages and uses information which is available in the Modelica
-	language specification and/or the corresponding Modelica package.</p>
-</ol>
-
-<p><b>Can I sell a manual
-that was basically derived by extracting information automatically
-from a Modelica package under Modelica License 2 (e.g., a &ldquo;reference
-guide&rdquo; of the Modelica Standard Library):</b></p>
-<p>Yes.
-Extracting information from a Modelica package, and providing it in a
-human readable, suitable format, like html, doc or pdf format, where
-the content is significantly modified (e.g. tables with interface
-information are constructed from the declarations of the public
-variables) qualifies as Derivative Work and there are no restrictions
-to charge a fee for Derivative Work under alternative 2d).</p>
-
-<p><b>Can
-I copy a text passage out of a Modelica document (under Modelica
-License 2) and use it </b><u><b>unmodified</b></u><b> in my document
-(e.g. the Modelica syntax description in the Modelica Specification)?</b></p>
-<p>Yes.
-In case you distribute your document, the copied parts are still
-under Modelica License 2 and you are not allowed to charge a license
-fee for this part. You can, of course, charge a fee for the rest of
-your document.</p>
-
-<p><b>Can
-I copy a text passage out of a Modelica document (under Modelica
-License 2) and use it in </b><u><b>modified</b></u><b> form in my
-document?</b></p>
-<p>Yes,
-the creation of Derivative Works is allowed. In case the content is
-significantly modified this qualifies as Derivative Work and there
-are no restrictions to charge a fee for Derivative Work under
-alternative 2d).</p>
-
-<p><b>Can I sell a printed
-version of a Modelica document (under Modelica License 2), e.g., the
-Modelica Language Specification?</b></p>
-<p>No,
-if you are not the copyright-holder, since article 2c) does not allow
-a selling fee for a (in this case physical) copy. However, mere
-printing and shipping costs may be recovered.</p>
 </html>"));
 
   end The3clauseBSDLicense;
@@ -857,7 +619,8 @@ This library is based on the following references:
 
   package ReleaseNotes "Release notes"
     class Version_2_3_5 "Version 2.3.5 (March 20, 2019)"
-	extends Modelica.Icons.ReleaseNotes;
+      extends
+         Modelica.Icons.ReleaseNotes;
 
       annotation (Documentation(info="<html>
 <p>This version requires the <b>Modelica 3.2.3</b> Library.
@@ -872,6 +635,7 @@ Improvements in this version:
 </ul>
 </html>"));
     end Version_2_3_5;
+
     class Version_2_3_4 "Version 2.3.4 (March 11, 2016)"
       extends Modelica.Icons.ReleaseNotes;
 


### PR DESCRIPTION
The Frequently_Asked_Questions section referenced Modelica license 2 only.